### PR TITLE
Enable travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
 script:
   - make codecheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+install:
+  - pip install -r requirements.txt
+script:
+  - make codecheck


### PR DESCRIPTION
This commit enables paws to have a travis-ci job running for any new pull request or merge of a branch into master branch. The job will run the **make codecheck** command to verify the pep8 and pylint code standards are 10/10 for each new pull request.