### PR TITLE
lock paramiko to set version to resolve gssapi incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ and configure Windows services with a simpler way to test hybrid environments \
               'paws.providers',
               'paws.tasks'
     ],
-    install_requires=['paramiko',
+    install_requires=['paramiko==2.2.1',
                       'pywinrm',
                       'click',
                       'apache-libcloud',


### PR DESCRIPTION
This will resolve the bug found when a user has the gssapi library
installed and then tries to run paws. When they go to run paws, it
will fail with a paramiko exception. Rolling back the version resolves
this bug. To note: paws does not require gssapi. We will upgrade to
the latest version of paramiko once they fix the bug.

More information can be referenced in #9

Closes #9 