### PR TITLE
use readthedocs over github pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ help:
 
 	@echo -e "\t$(OK_COLOR)--- doc ---$(NO_COLOR)"
 	@echo -e "\t$(WARN_COLOR)doc$(NO_COLOR)                generate sphinx doc html and man pages"
-	@echo -e "\t$(WARN_COLOR)gh-pages$(NO_COLOR)           publish html doc to github pages"
 
 	@echo -e "\t$(OK_COLOR)--- pip ---$(NO_COLOR)"	
 	@echo -e "\t$(WARN_COLOR)pip$(NO_COLOR)                build source codes and generate tar.gz file"
@@ -140,9 +139,6 @@ doc: prep set-version
 	@echo -e "$(OK_COLOR)html doc saved at: ../paws-doc/html/index.html$(NO_COLOR)"
 	@echo -e "$(OK_COLOR)man page saved at: ../paws-doc/man/paws.1$(NO_COLOR)"
 	@echo
-
-gh-pages:
-	make -C doc/ gh-pages
 
 copr-dev: srpm
 	# for devel and ci we use internal copr

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/paws-cli.svg)](https://badge.fury.io/py/paws-cli)
+[![Documentation Status](https://readthedocs.com/projects/rhpit-paws/badge/?version=latest)](https://rhpit-paws.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/rhpit/paws.svg?branch=master)](https://travis-ci.org/rhpit/paws)
 
 # PAWS :: Provision Automated Windows and Services
 
@@ -52,7 +54,8 @@ use PAWS to replicate the Windows environment based on scripts.
 
 ## Full documentation
 
-To know more access the full documentation at https://rhpit.github.io/paws/
+To know more access the full documentation at
+https://rhpit-paws.readthedocs-hosted.com/en/latest/
 
 
 ## Report an issue

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,7 +24,6 @@ help:
 	@echo -e "\t$(WARN_COLOR)html$(NO_COLOR)       to make html doc available at $(GHPAGES)"
 	@echo -e "\t$(WARN_COLOR)man$(NO_COLOR)        to make manpage available at $(MANPAGES)"
 	@echo -e "\t$(WARN_COLOR)doc$(NO_COLOR)        to make man and html"
-	@echo -e "\t$(WARN_COLOR)gh-pages$(NO_COLOR)   to make doc and push gh-pages branch to github pages"
 	@echo -e "$(NO_COLOR)"
 	@echo
 
@@ -59,14 +58,4 @@ html:
 doc: prep
 	make man
 	make html
-	@echo
-	
-# generate html documentation and push to github pages
-gh-pages: doc
-	cd $(GHPAGES) && git fetch --all
-	cd $(GHPAGES) && git add . 
-	cd $(GHPAGES) && git commit -m "Generated gh-pages for `git log origin/master -1 --pretty=short --abbrev-commit`"
-	cd $(GHPAGES) && git push origin gh-pages
-	@echo -e "$(OK_COLOR)documentation published to https://rhpit.github.io/paws/$(NO_COLOR)"	
-	@echo -e "$(WARN_COLOR)might take some seconds/minute to update$(NO_COLOR)"
 	@echo

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -153,9 +153,8 @@ List of actions that need to be performed for a new release:
 3. make codecheck -- fix if needed
 4. commit your changes
 5. make doc ( access locally and double check before update upstream doc )
-6. make gh-pages -- if needed
-7. make copr-dev
-8. make copr-upstream
+6. make copr-dev
+7. make copr-upstream
 
 IDE
 ----


### PR DESCRIPTION
Read the docs provides the ability for documentation per versions. This
is nice when a user sticks with a certain version of paws, they can
continue to see the docuemntation for that version. Example would be if
paws changes all parameter inputs, you can see the prior docs has the
original parameter input for paws.

https://rhpit.github.io/paws will redirect to https://rhpit-paws.readthedocs-hosted.com