### PR TITLE
python 3 compatibility enhancements

### DIFF
--- a/paws/compat.py
+++ b/paws/compat.py
@@ -21,9 +21,9 @@
 import sys
 
 try:
-    from ConfigParser import ConfigParser
+    from ConfigParser import RawConfigParser
 except ImportError:
-    from configparser import ConfigParser
+    from configparser import RawConfigParser
 
 try:
     from xmlrpclib import ServerProxy

--- a/paws/helpers.py
+++ b/paws/helpers.py
@@ -17,7 +17,6 @@
 #
 """Helpers module."""
 
-from functools import wraps
 from json import dump as json_dump
 from json import load as json_load
 from logging import getLogger
@@ -26,6 +25,7 @@ from subprocess import Popen
 from time import sleep
 
 from click_spinner import spinner
+from functools import wraps
 from os import remove, listdir
 from os.path import join, exists, splitext
 from paramiko import AutoAddPolicy, SSHClient

--- a/paws/lib/remote.py
+++ b/paws/lib/remote.py
@@ -19,12 +19,12 @@
 """Module containing classes and functions regarding remote connections."""
 
 import sys
-from collections import namedtuple
 from logging import getLogger
 from pprint import pformat
 
 import os
 from click_spinner import spinner
+from collections import namedtuple
 
 try:
     # < 2.4
@@ -42,7 +42,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
 
-from paws.compat import ConfigParser
+from paws.compat import RawConfigParser
 from paws.constants import ANSIBLE_INVENTORY_FILENAME as ANSIBLE_INVENTORY
 from paws.helpers import retry
 from paws.helpers import file_mgmt
@@ -117,14 +117,14 @@ def create_inventory(filename, resources=None):
     if inventory_reuse(filename, resources):
         return
 
-    config = ConfigParser()
+    config = RawConfigParser()
 
     for item in resources['resources']:
         section = item['name'].replace(" ", "")
         config.add_section(section)
 
         try:
-            config.set(section, item['public_v4'])
+            config.set(section, str(item['public_v4']))
         except KeyError:
             config.set(section, item['ip'])
 

--- a/paws/main.py
+++ b/paws/main.py
@@ -21,7 +21,6 @@ Main class
 """
 
 from importlib import import_module
-
 from os import environ, getcwd
 from os.path import join, isdir
 

--- a/paws/providers/openstack.py
+++ b/paws/providers/openstack.py
@@ -16,13 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import random
-from copy import deepcopy
 from time import sleep
 from uuid import uuid4
 
+import random
 import urllib3
 from click_spinner import spinner
+from copy import deepcopy
 from libcloud import security
 from libcloud.common.types import InvalidCredsError
 from libcloud.compute.providers import get_driver
@@ -79,8 +79,8 @@ class LibCloud(LoggerMixin):
         """
         images = self.driver.list_images()
 
-        by_name = filter(lambda elm: elm.name == name, images)
-        by_id = filter(lambda elm: elm.id == name, images)
+        by_name = list(filter(lambda elm: elm.name == name, images))
+        by_id = list(filter(lambda elm: elm.id == name, images))
 
         if by_name.__len__() != 0:
             return by_name[0]
@@ -96,7 +96,7 @@ class LibCloud(LoggerMixin):
         """
         sizes = self.driver.list_sizes()
 
-        by_name = filter(lambda elm: elm.name == name, sizes)
+        by_name = list(filter(lambda elm: elm.name == name, sizes))
         by_id = list()
 
         for size in sizes:
@@ -122,7 +122,7 @@ class LibCloud(LoggerMixin):
         """
         pairs = self.driver.list_key_pairs()
 
-        data = filter(lambda elm: elm.name == name, pairs)
+        data = list(filter(lambda elm: elm.name == name, pairs))
 
         if data.__len__() == 0:
             raise NotFound('Not found key pair: %s.' % name)
@@ -136,7 +136,7 @@ class LibCloud(LoggerMixin):
         """
         pool = self.driver.ex_list_floating_ip_pools()
 
-        data = filter(lambda elm: elm.name == name, pool)
+        data = list(filter(lambda elm: elm.name == name, pool))
 
         if data.__len__() == 0:
             raise NotFound('Not found floating ip pool: %s.' % name)
@@ -150,7 +150,7 @@ class LibCloud(LoggerMixin):
         """
         nodes = self.driver.list_nodes()
 
-        data = filter(lambda elm: elm.name == name, nodes)
+        data = list(filter(lambda elm: elm.name == name, nodes))
 
         if data.__len__() == 0:
             raise NotFound('Not found vm: %s.' % name)
@@ -262,7 +262,7 @@ class LibCloud(LoggerMixin):
         """
         networks = self.driver.ex_list_networks()
 
-        data = filter(lambda elm: elm.name == name, networks)
+        data = list(filter(lambda elm: elm.name == name, networks))
 
         if data.__len__() == 0:
             raise NotFound('Not found network: %s.' % name)

--- a/paws/tasks/group.py
+++ b/paws/tasks/group.py
@@ -18,10 +18,10 @@
 
 """Group task."""
 
-from importlib import import_module
 from time import sleep
 
 import re
+from importlib import import_module
 from os.path import join
 
 from paws.constants import GROUP_SECTIONS, GROUP_SCHEMA, TASK_ARGS, \


### PR DESCRIPTION
This PR resolves errors found when trying to run paws on Python 3. With these changes, paws is able to run all tasks successfully on Python 2.7+ and Python 3.6+.