### PR TITLE
bug fix to resolve paws hanging when releasing ipv4 connections

### DIFF
--- a/paws/lib/windows.py
+++ b/paws/lib/windows.py
@@ -152,7 +152,8 @@ def ipconfig_release(res):
         res['public_v4'],
         res['win_username'],
         'ipconfig /release',
-        password=res['win_password']
+        password=res['win_password'],
+        fire_forget=True
     )
 
     LOG.info('Successfully released IPv4 addresses for vm: %s.', res['name'])


### PR DESCRIPTION
This commit resolves a bug found when trying to create snapshots from
a configured Windows system. Before creating the snapshot, paws releases
all ipv4 connections to ensure networking will work when a new instance
is created based on the snapshot. The command needs to be a fire and
forget call, since it looses network connectivity immediately. A fix
is in place to fire and forget the command.