### PR TITLE
verify pep8 for new pull requests only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 install:
   - pip install -r test-requirements.txt
 script:
-  - tox
+  - tox -e pep8


### PR DESCRIPTION
Fixes Travis CI for all new pull requests. Travis CI is used to verify pep8 standards.