### PR TITLE
adds missing parameter to results class constructor

### DIFF
--- a/paws/lib/remote.py
+++ b/paws/lib/remote.py
@@ -276,9 +276,9 @@ class GenModuleResults(ResultsHandler):
     DEPRECATED with 0.5.0 release. This class aligns with winsetup task.
     """
 
-    def __init__(self, exit_code, callback):
+    def __init__(self, exit_code, callback, def_callback):
         """Constructor."""
-        ResultsHandler.__init__(self, exit_code, callback)
+        ResultsHandler.__init__(self, exit_code, callback, def_callback)
 
     def process(self):
         """Process results."""


### PR DESCRIPTION
Adds back a required parameter for the GenModuleResults class. This class will no longer be supported after v0.5.0.