### PR TITLE
add new test to test paws configure task

### DIFF
--- a/tests/integration/test_docker_images.py
+++ b/tests/integration/test_docker_images.py
@@ -147,6 +147,15 @@ class TestDockerImages(object):
         assert not results
 
     @staticmethod
+    def test_configure(client):
+        container = start_container(client)
+        results = run_cmd(
+            container, 'paws -v configure powershell/get_system_info.ps1'
+        )
+        delete_container(container)
+        assert not results
+
+    @staticmethod
     def test_teardown(client):
         container = start_container(client)
         results = run_cmd(container, 'paws -v teardown')


### PR DESCRIPTION
This PR adds a new test case to the integration module. It is a positive test case for paws new configure task. Which is replacing the winsetup task in release 0.5.0.