### PR TITLE
ability to state attempts and delay when checking snapshot building

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -151,6 +151,16 @@ Path: /home/$USER/ws/resources.yaml
              create: False
              clean: True
 
+      # example 3: create snapshot, override default settings for attempts and
+      # delay between attempts when checking if snapshot was created
+      # default attempts is 30 and default delay is 20 seconds
+      resources:
+         - name: MY_WINDOWS_VM
+           snapshot:
+             create: True
+             attempts: 60
+             delay: 30
+
 single network
 ^^^^^^^^^^^^^^
 

--- a/paws/providers/openstack.py
+++ b/paws/providers/openstack.py
@@ -597,6 +597,17 @@ class OpenStack(LibCloud):
             )
             return
 
+        # default settings for snapshot checking values
+        attempts = 30
+        delay = 20
+
+        # user override default snapshot checking values
+        if 'attempts' in snap_details:
+            attempts = int(snap_details['attempts'])
+
+        if 'delay' in snap_details:
+            delay = int(snap_details['delay'])
+
         # create image
         image_id = ''
         if snap_details['create']:
@@ -622,8 +633,7 @@ class OpenStack(LibCloud):
 
             # wait for image upload to complete
             attempt = 1
-            max_attempts = 30
-            while attempt <= max_attempts:
+            while attempt <= attempts:
                 image = self.driver.get_image(image_id)
                 if image.extra['status'].lower() == 'active':
                     self.logger.info('Image: %s, id: %s upload complete!',
@@ -631,12 +641,12 @@ class OpenStack(LibCloud):
                     break
                 else:
                     self.logger.info('%s:%s. Image: %s, id: %s status: %s. '
-                                     'Rechecking in 20 seconds.', attempt,
-                                     max_attempts, image.name, image.id,
-                                     image.extra['status'])
-                    sleep(20)
+                                     'Rechecking in %s seconds.', attempt,
+                                     attempts, image.name, image.id,
+                                     image.extra['status'], delay)
+                    sleep(delay)
                     attempt += 1
-                if attempt == max_attempts:
+                if attempt == attempts:
                     self.logger.error('Image: %s, id: %s failed to become '
                                       'active!', image.name, image.id)
                     self.driver.ex_hard_reboot_node(node)


### PR DESCRIPTION
By default when paws goes to take a snapshot of an active instance, it
has a default number of attempts (30) and a default time to wait (20s)
between attempts. There is cases where these default values are
exceeded. This commit allows the user to define custom values for these
when checking if the snapshot build is complete.

closes #34 