### PR TITLE
ability to override the default attempts for instance building

### DIFF
--- a/doc/files.rst
+++ b/doc/files.rst
@@ -72,6 +72,7 @@ Example resources.yaml for Openstack provider:
         keypair: my_key_pair
         ssh_private_key: /home/user/.ssh/id_rsa
         administrator_password: my_password@2016
+        provision_attempts: 30
 
 .. note::
 

--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -66,6 +66,7 @@ Path: /home/$USER/ws/resources.yaml
         keypair: <keypair>
         ssh_private_key: /home/$USER/.ssh/<private_key>
         administrator_password: my_password@2018
+        provision_attempts: 30
 
 *PS: resources accepts multiple resources definition.*
 
@@ -125,6 +126,10 @@ Path: /home/$USER/ws/resources.yaml
 | administrator_password | The administrator password to set |      No     |
 |                        | on the Windows system after       |             |
 |                        | provisioning has finished.        |             |
++------------------------+-----------------------------------+-------------+
+| provision_attempts     | The number of attempts to wait    |      No     |
+|                        | for the provision request to      |             |
+|                        | finish building. Default is 30.   |             |
 +------------------------+-----------------------------------+-------------+
 | snapshot               | Take a snapshot for a given       |      No     |
 |                        | resource.                         |             |


### PR DESCRIPTION
Previously paws would only do 30 attempts checking if an instance is
successfully provisioned. There is use cases where this number of
attempts is not enough and needs to be more. With this change, users
can now supply their own number of attempts when checking if an instance
is provisioned. Each resource can have their own unique number of
attempts.